### PR TITLE
Download themes and icons from Github repo

### DIFF
--- a/themes_manager.py
+++ b/themes_manager.py
@@ -93,8 +93,25 @@ def write_palette_h(data, file_p):
 # data = get_data(args.theme)
 
 def main(args):
+    if (args.download):
+        theme_url = args.theme
+        theme_name = args.theme.replace("/","_")
+        print("\nDownloading theme :\n" + theme_url)
+        # download the theme.json file from the repo
+        try:
+            resp_theme_json = urllib.request.urlopen("https://raw.githubusercontent.com/"+theme_url+"/theme.json")
+            data = resp_theme_json.read()
+            theme_json_file = open(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "themes" + os.path.sep + theme_name + ".json","wb")
+            print("\nSaving as '" + theme_name + "'" )
+            theme_json_file.write(data)
+            print("\nTheme sucessfully downloaded, exiting.")
+        except :
+            print("Error in downloading the theme, is the name valid ?")
+            sys.exit(1)
+        sys.exit(0)
+    
     if (args.list):
-        print(" ==== Official themes ====");
+        print(" ==== Available themes ====");
         for file_info in os.listdir(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "themes"):
             filename = os.path.splitext(file_info)[0]
             print(filename)
@@ -119,6 +136,11 @@ def main(args):
                 outFile = open(args.output,"wb")
                 data = response.read()
                 outFile.write(data)
+                # cache files 
+                cache_file = open(icon_path,"wb")
+                cache_file.write(data)
+
+
             except:
                 # If no, copy from src
                 print(" (!!)   Icon " + icons[args.output.replace(args.build_dir, "")] + " not found in icon theme " + data["icons"] + ". Using default!")
@@ -138,6 +160,7 @@ if __name__ == "__main__":
     parser.add_argument("-l", "--list", help="list themes", action="store_true")
     parser.add_argument("-i", "--icon", help="outputs an icon instead of a header", action="store_true")
     parser.add_argument("--stdout", help="print palette.h to stdout", action="store_true")
+    parser.add_argument("-d", "--download", help="download a theme from github", action="store_true")
 
     args = parser.parse_args()
     main(args)

--- a/themes_manager.py
+++ b/themes_manager.py
@@ -95,14 +95,16 @@ def write_palette_h(data, file_p):
 def main(args):
     if (args.download):
         theme_url = args.theme
+        # can’t save a file with slashes so replacing it with underscores
         theme_name = args.theme.replace("/","_")
         print("\nDownloading theme :\n" + theme_url)
         # download the theme.json file from the repo
         try:
             resp_theme_json = urllib.request.urlopen("https://raw.githubusercontent.com/"+theme_url+"/theme.json")
             data = resp_theme_json.read()
-            theme_json_file = open(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "themes" + os.path.sep + theme_name + ".json","wb")
+
             print("\nSaving as '" + theme_name + "'" )
+            theme_json_file = open(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "themes" + os.path.sep + theme_name + ".json","wb")
             theme_json_file.write(data)
             print("\nTheme sucessfully downloaded, exiting.")
         except :
@@ -136,13 +138,8 @@ def main(args):
                 outFile = open(args.output,"wb")
                 data = response.read()
                 outFile.write(data)
-                # cache files 
-                cache_file = open(icon_path,"wb")
-                cache_file.write(data)
-
-
             except:
-                # If no, copy from src
+                # If download failed, copy from src
                 print(" (!!)   Icon " + icons[args.output.replace(args.build_dir, "")] + " not found in icon theme " + data["icons"] + ". Using default!")
                 shutil.copyfile(args.output.replace(args.build_dir, ""), args.output)
     else:

--- a/themes_manager.py
+++ b/themes_manager.py
@@ -3,7 +3,7 @@ import argparse
 import os
 import json
 import shutil
-
+import urllib.request
 
 def get_icons_list():
     """
@@ -11,7 +11,6 @@ def get_icons_list():
     """
     with open(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "icons.json", "r") as json_file:
         data = json.load(json_file)
-    
     return data
 
 def get_data(theme):
@@ -95,7 +94,7 @@ def write_palette_h(data, file_p):
 
 def main(args):
     if (args.list):
-        print(" ==== Avaliable themes ====");
+        print(" ==== Official themes ====");
         for file_info in os.listdir(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "themes"):
             filename = os.path.splitext(file_info)[0]
             print(filename)
@@ -108,15 +107,22 @@ def main(args):
         icons = get_icons_list()
         
         icon_path = os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "icons" + os.path.sep + data["icons"] + os.path.sep + icons[args.output.replace(args.build_dir, "")]
-        
+       
         # Check if the file exists
         if os.path.isfile(icon_path):
             # If yes, copy from theme
             shutil.copyfile(icon_path, args.output)
         else:
-            # If no, copy from src
-            print(" (!!)   Icon " + icons[args.output.replace(args.build_dir, "")] + " not found in icon theme " + data["icons"] + ". Using default!")
-            shutil.copyfile(args.output.replace(args.build_dir, ""), args.output)
+            #try to download from github
+            try:
+                response = urllib.request.urlopen("https://raw.githubusercontent.com/"+data["icons"]+"/"+icons[args.output.replace(args.build_dir, "")])
+                outFile = open(args.output,"wb")
+                data = response.read()
+                outFile.write(data)
+            except:
+                # If no, copy from src
+                print(" (!!)   Icon " + icons[args.output.replace(args.build_dir, "")] + " not found in icon theme " + data["icons"] + ". Using default!")
+                shutil.copyfile(args.output.replace(args.build_dir, ""), args.output)
     else:
         if (args.stdout):
             write_palette_h(data, sys.stdout)


### PR DESCRIPTION
If the file/folder is not found, `theme_manager.py` will try to download the icons from github.
The given icon path need to point to the folder containing the icons. 
This path needs to correspond to the path of the folder in "download mode" (when you click download in the interface of Github).

For example with my theme the complete url would be `https://raw.githubusercontent.com/NilsPonsard/Omega-Themes/master/icons/omega_nord/` but you only need the part after `https://raw.githubusercontent.com/` so the path in the `theme.json` file is 
```json
"icons": "NilsPonsard/Omega-Themes/master/icons/omega_nord",
```

I don’t know if my explanation is clear, if not, feel free to ask details

I added the ability to download a theme file from a github repo as explained here : [https://github.com/NilsPonsard/Omega-theme-template](https://github.com/NilsPonsard/Omega-theme-template)
